### PR TITLE
Revert icon on A08 and A10 master file

### DIFF
--- a/2021/docs/A08_2021-Software_and_Data_Integrity_Failures.md
+++ b/2021/docs/A08_2021-Software_and_Data_Integrity_Failures.md
@@ -1,5 +1,4 @@
-# A08:2021 – Software and Data Integrity Failures
-<img src="https://raw.githubusercontent.com/OWASP/Top10/master/2021/docs/assets/TOP_10_Icons_Final_Software_and_Data_Integrity_Failures.png" alt="icon" height=80px width=80px align="center">
+# A08:2021 – Software and Data Integrity Failures    ![icon](assets/TOP_10_Icons_Final_Software_and_Data_Integrity_Failures.png){: style="height:80px;width:80px" align="right"}
 
 ## Factors
 

--- a/2021/docs/A10_2021-Server-Side_Request_Forgery_(SSRF).md
+++ b/2021/docs/A10_2021-Server-Side_Request_Forgery_(SSRF).md
@@ -1,5 +1,4 @@
-# A10:2021 – Server-Side Request Forgery (SSRF)
-<img src="https://raw.githubusercontent.com/OWASP/Top10/master/2021/docs/assets/TOP_10_Icons_Final_SSRF.png" alt="icon" height=80px width=80px align="center">
+# A10:2021 – Server-Side Request Forgery (SSRF)    ![icon](assets/TOP_10_Icons_Final_SSRF.png){: style="height:80px;width:80px" align="right"}
 
 ## Factors
 


### PR DESCRIPTION
This pull request is to revert the original/master icon, previously i tried to fix the icon by using `html` but when `owasp-id` tried to PR to `OWASP` Master there is a conflict on A08 and A10 master file i suppose caused by this icons.

This PR is here to make amend for both file's icon, and lastly to follow the original master file convention on icon.